### PR TITLE
CI: Configure workflow to build Android and iOS on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,4 +40,4 @@ jobs:
           distribution: 'adopt'
 
       - name: Build with Xcode
-        run: xcodebuild -workspace iosApp/iosApp.xcodeproj/project.xcworkspace -configuration Debug -scheme alkaa -sdk iphonesimulator
+        run: xcodebuild -workspace iosApp.xcworkspace -scheme iosApp -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 15' build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         run: ./gradlew clean build test --parallel
 
   build-ios:
-    runs-on: macos-14
+    runs-on: macos-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,43 +1,28 @@
-name: Build project
-
+name: Build
 on:
   pull_request:
-    paths-ignore:
-      - '**.md'
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  push:
+    branches: [ main, develop ]
+  workflow_dispatch:
 
 jobs:
-  build-android:
-    runs-on: ubuntu-latest
-
+  build:
+    runs-on: macos-latest
     steps:
-      - name: Checkout
+      - name: Checkout source code
         uses: actions/checkout@v4
 
-      - name: Setup Java
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           java-version: '21'
-          distribution: 'adopt'
+          distribution: 'corretto'
 
-      - name: Build with Gradle
-        run: ./gradlew :composeApp:assembleDebug
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
-  build-ios:
-    runs-on: macos-15
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          java-version: '21'
-          distribution: 'adopt'
-
-      - name: Build with Xcode
-        run: ./gradlew :composeApp:linkDebugFrameworkIosSimulatorArm64
+      - name: Check, Assemble Android and compile iOS
+        run: ./gradlew assembleDebug compileKotlinIosX64 --no-daemon

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,4 +40,4 @@ jobs:
           distribution: 'adopt'
 
       - name: Build with Xcode
-        run: xcodebuild -allowProvisioningUpdates -project iosApp/iosApp.xcodeproj -configuration Debug -scheme iosApp -sdk iphoneos -destination name='iPhone 16'
+        run: ./gradlew :composeApp:linkDebugFrameworkIosSimulatorArm64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'adopt'
 
       - name: Build with Gradle
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'adopt'
 
       - name: Build with Xcode

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,9 @@
 name: Build project
 
 on:
-  push:
-    branches:
-      - main
-      - develop
+  pull_request:
     paths-ignore:
       - '**.md'
-  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         run: ./gradlew clean build test --parallel
 
   build-ios:
-    runs-on: macos-latest
+    runs-on: macos-15
 
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,28 +1,56 @@
-name: Build
+name: Build Android and iOS Apps
+
 on:
-  pull_request:
   push:
-    branches: [ main, develop ]
-  workflow_dispatch:
+  pull_request:
 
 jobs:
-  build:
-    runs-on: macos-latest
+  build-android:
+    runs-on: ubuntu-latest
+
     steps:
-      - name: Checkout source code
+      - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up JDK 21
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
-          distribution: 'corretto'
+          java-version: '17'
+          distribution: 'temurin'
 
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
 
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+      - name: Build with Gradle
+        run: ./gradlew assemble
 
-      - name: Check, Assemble Android and compile iOS
-        run: ./gradlew :composeApp:assembleDebug :composeApp:compileKotlinIosSimulatorArm64 --no-daemon
+      - name: Store build outputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-build-outputs
+          path: composeApp/build/outputs/
+
+  build-ios:
+    runs-on: macos-14
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: Build iOS binaries
+        run: ./gradlew composeApp:iosArm64Binaries
+
+      - name: Store iOS binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-binaries
+          path: composeApp/build/bin/iosArm64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,4 +40,4 @@ jobs:
           distribution: 'adopt'
 
       - name: Build with Xcode
-        run: xcodebuild -allowProvisioningUpdates -project iosApp/iosApp.xcodeproj -configuration Debug -scheme iosApp -sdk iphoneos -destination name='iPhone 15'
+        run: xcodebuild -allowProvisioningUpdates -project iosApp/iosApp.xcodeproj -configuration Debug -scheme iosApp -sdk iphoneos -destination name='iPhone 16'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Build with Gradle
-        run: ./gradlew clean build test --parallel
+        run: ./gradlew :composeApp:assembleDebug
 
   build-ios:
     runs-on: macos-15

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,4 +25,4 @@ jobs:
         uses: android-actions/setup-android@v3
 
       - name: Check, Assemble Android and compile iOS
-        run: ./gradlew assembleDebug compileKotlinIosX64 --no-daemon
+        run: ./gradlew :composeApp:assembleDebug :composeApp:compileKotlinIosSimulatorArm64 --no-daemon

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,3 +29,19 @@ jobs:
 
       - name: Build with Gradle
         run: ./gradlew clean build test --parallel
+
+  build-ios:
+    runs-on: macos-14
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+
+      - name: Build with Xcode
+        run: xcodebuild -workspace iosApp/iosApp.xcodeproj/project.xcworkspace -configuration Debug -scheme alkaa -sdk iphonesimulator

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,4 +40,4 @@ jobs:
           distribution: 'adopt'
 
       - name: Build with Xcode
-        run: xcodebuild -workspace iosApp.xcworkspace -scheme iosApp -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 15' build
+        run: xcodebuild -allowProvisioningUpdates -project iosApp/iosApp.xcodeproj -configuration Debug -scheme iosApp -sdk iphoneos -destination name='iPhone 15'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Build project
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+    paths-ignore:
+      - '**.md'
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-android:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+
+      - name: Build with Gradle
+        run: ./gradlew clean build test --parallel

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -1,0 +1,159 @@
+name: iOS CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+env:
+  JAVA_VERSION: 21
+
+jobs:
+  ios-build:
+    name: iOS Build Check
+    runs-on: macos-15
+    timeout-minutes: 30
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: ${{ env.JAVA_VERSION }}
+      
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
+          cache-read-only: 'true'
+          cache-cleanup: on-success
+      
+    #   - name: Create local.properties
+        # run: echo "sdk.dir=$ANDROID_HOME" > ./local.properties
+      
+      - name: Cache Kotlin Multiplatform builds
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.konan
+            composeApp/build
+            composeApp/.gradle
+          key: ${{ runner.os }}-kmp-${{ hashFiles('composeApp/**/*.kt', 'composeApp/build.gradle.kts', 'gradle/libs.versions.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-kmp-
+      
+      - name: Cache Homebrew
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/Homebrew
+            /usr/local/Homebrew
+          key: ${{ runner.os }}-homebrew-${{ hashFiles('**/Brewfile') }}
+          restore-keys: |
+            ${{ runner.os }}-homebrew-
+      
+      - name: Cache SwiftGen
+        uses: actions/cache@v4
+        with:
+          path: /usr/local/bin/swiftgen
+          key: ${{ runner.os }}-swiftgen-${{ hashFiles('iosApp/iosApp/SwiftGen/swiftgen.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-swiftgen-
+      
+      - name: Install SwiftGen
+        run: |
+          if ! command -v swiftgen &> /dev/null; then
+            brew install swiftgen
+          else
+            echo "SwiftGen already installed"
+          fi
+      
+      - name: Cache Xcode DerivedData
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Developer/Xcode/DerivedData
+            build
+          key: ${{ runner.os }}-xcode-deriveddata-${{ hashFiles('iosApp/iosApp.xcodeproj/project.pbxproj') }}-${{ hashFiles('composeApp/**/*.kt') }}
+          restore-keys: |
+            ${{ runner.os }}-xcode-deriveddata-${{ hashFiles('iosApp/iosApp.xcodeproj/project.pbxproj') }}-
+            ${{ runner.os }}-xcode-deriveddata-
+      
+      - name: Select Xcode version
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+      
+      - name: Show Xcode version
+        run: xcodebuild -version
+      
+      - name: Show available simulators
+        run: xcrun simctl list devices available
+      
+      - name: Build shared framework
+        run: |
+          # Set required Xcode environment variables for the Gradle task
+          export SDK_NAME=iphonesimulator
+          export CONFIGURATION=Debug
+          export TARGET_BUILD_DIR=${{ github.workspace }}/build/ios
+          export BUILT_PRODUCTS_DIR=${{ github.workspace }}/build/ios
+          export FRAMEWORKS_FOLDER_PATH=Frameworks
+          export ARCHS=arm64
+          
+          # Create the target directory
+          mkdir -p "$TARGET_BUILD_DIR"
+          
+          # Run the Gradle task with Xcode environment
+          ./gradlew :shared:embedAndSignAppleFrameworkForXcode
+      
+      - name: Cache SwiftGen generated files
+        uses: actions/cache@v4
+        with:
+          path: |
+            iosApp/iosApp/SwiftGen/Strings.swift
+            iosApp/iosApp/SwiftGen/Assets.swift
+          key: ${{ runner.os }}-swiftgen-generated-${{ hashFiles('iosApp/iosApp/Resources/**/*', 'iosApp/iosApp/SwiftGen/swiftgen.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-swiftgen-generated-
+      
+      - name: Generate SwiftGen files
+        working-directory: iosApp/iosApp/SwiftGen
+        run: |
+          if [ ! -f "Strings.swift" ] || [ ! -f "Assets.swift" ]; then
+            echo "Generating SwiftGen files..."
+            swiftgen config run
+          else
+            echo "SwiftGen files already exist and are cached"
+          fi
+      
+      - name: List available schemes
+        run: |
+          echo "Listing project schemes and targets..."
+          xcodebuild -project iosApp/iosApp.xcodeproj -list
+          echo "Project listing complete."
+      
+      - name: Resolve Swift Package Dependencies
+        run: |
+          echo "Resolving Swift Package dependencies..."
+          xcodebuild \
+            -project iosApp/iosApp.xcodeproj \
+            -resolvePackageDependencies
+          echo "Package dependencies resolved."
+
+      - name: Build iOS App for Simulator
+        run: |
+          echo "Starting iOS build..."
+          xcodebuild \
+            -project iosApp/iosApp.xcodeproj \
+            -scheme "iosApp" \
+            -configuration Debug \
+            -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.3.1' \
+            -derivedDataPath build \
+            build \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
+            PROVISIONING_PROFILE=""

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -50,7 +50,7 @@ kotlin {
             implementation(libs.lifecycle.viewmodel)
 
             // navigation
-            implementation(libs.androidx.navigation.compose)
+            implementation(libs.navigation.compose)
 
             // koin
             api(libs.koin.core)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,8 +13,8 @@ androidx-testExt = "1.2.1"
 composeMultiplatform = "1.8.2"
 junit = "4.13.2"
 kotlin = "2.2.0"
+navigationCompose = "2.9.0-beta04"
 coil3="3.3.0"
-navigationCompose = "2.9.3"
 koin = "4.1.0"
 koinComposeMultiplatform = "4.1.0"
 lifecycleViewModel = "2.9.2"
@@ -36,7 +36,7 @@ coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil3"
 lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel", version.ref = "lifecycleViewModel"}
 
 # navigation
-androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
+navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 
 # koin
 koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }


### PR DESCRIPTION
This PR introduces a GitHub Actions workflow to build and test the Android and iOS applications. The workflow is triggered on every pull request (ignoring changes to markdown files) and includes jobs for:

- Building and testing the Android app using Gradle.
- Building the iOS app using Xcode.

Fixes #38