### PR TITLE
refactor: Update email validation regex and error messages

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ar/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ar/strings.xml
@@ -213,7 +213,7 @@
 
     <string name="error_no_internet">لا يوجد اتصال بالإنترنت.</string>
     <string name="error_unknown_credentials">البريد الإلكتروني أو كلمة المرور غير صحيحة.</string>
-    <string name="error_invalid_email_format">تنسيق البريد الإلكتروني غير صحيح.</string>
+    <string name="error_invalid_email_format">تنسيق البريد الإلكتروني غير صحيح.التنسيق الصحيح: example@domain.com.</string>
     <string name="error_invalid_password">يجب أن تكون كلمة المرور 8 أحرف على الأقل.</string>
     <string name="error_unexpected">حدث خطأ غير متوقع.</string>
     <string name="liters1">لترات</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -210,7 +210,7 @@
 
     <string name="error_no_internet">There is no internet connection.</string>
     <string name="error_unknown_credentials">Email or password you entered are incorrect.</string>
-    <string name="error_invalid_email_format">Invalid email format.</string>
+    <string name="error_invalid_email_format">Invalid email format. valid format is: example@domain.com.</string>
     <string name="error_invalid_password">Password must be at least 8 characters.</string>
     <string name="error_unexpected">An unexpected error occurred.</string>
     <string name="liters1">Litres</string>

--- a/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/domain/usecase/authentication/AuthenticationUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/domain/usecase/authentication/AuthenticationUseCase.kt
@@ -46,7 +46,7 @@ class AuthenticationUseCase(
 
     private fun isValidEmail(email: String): Boolean {
         val emailRegex = Regex("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}$")
-        return email.matches(emailRegex)
+        return email.trim().matches(emailRegex)
     }
 
     private fun isValidPassword(password: String): Boolean {


### PR DESCRIPTION
- Trim email string before regex matching in `AuthenticationUseCase`
- Update `error_invalid_email_format` string resource to include example