### PR TITLE
Fix/text under image should not be cliped as image

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/ui/screen/more/content/MoreScreenContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/ui/screen/more/content/MoreScreenContent.kt
@@ -261,16 +261,16 @@ fun ProfileInfo(
     modifier: Modifier = Modifier
 ) {
     Column(
-        modifier = modifier.clip(RoundedCornerShape(8.dp)),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = modifier,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         NetworkImage(
             model = userImage,
             contentDescription = stringResource(Res.string.profile_image),
-            modifier = Modifier.size(80.dp).clip(shape = CircleShape)
+            modifier = Modifier.size(80.dp).clip(shape = CircleShape).padding(bottom=12.dp)
         )
         Text(
+            modifier= Modifier.padding(bottom=4.dp),
             text = userName,
             color = Theme.color.surfaces.onSurfaceContainer,
             style = Theme.textStyle.label.mediumMedium14

--- a/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/ui/screen/more/content/MoreScreenContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/ui/screen/more/content/MoreScreenContent.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import com.cairosquad.evolvefit.design_system.component.BottomSheet
 import com.cairosquad.evolvefit.design_system.theme.Theme
@@ -267,10 +268,12 @@ fun ProfileInfo(
         NetworkImage(
             model = userImage,
             contentDescription = stringResource(Res.string.profile_image),
-            modifier = Modifier.size(80.dp).clip(shape = CircleShape).padding(bottom=12.dp)
+            modifier = Modifier
+                .size(80.dp)
+                .clip(shape = CircleShape)
         )
         Text(
-            modifier= Modifier.padding(bottom=4.dp),
+            modifier= Modifier.padding(bottom=4.dp,top=12.dp),
             text = userName,
             color = Theme.color.surfaces.onSurfaceContainer,
             style = Theme.textStyle.label.mediumMedium14


### PR DESCRIPTION
before
<img width="392" height="256" alt="image" src="https://github.com/user-attachments/assets/961c66ce-7f17-4bff-a98b-372ade60a359" />

after
<img width="697" height="390" alt="image" src="https://github.com/user-attachments/assets/95995cd4-8199-4513-8889-98b94780c37d" />
