### PR TITLE
Fix/nutrition issues UI

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/design_system/component/NavigationBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/design_system/component/NavigationBar.kt
@@ -15,7 +15,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -61,9 +61,11 @@ fun NavigationBar(
     selectedItem: Int = 0,
 ) {
     Row(
-        modifier = modifier.height(72.dp).background(Theme.color.surfaces.surface).fillMaxSize()
-            .padding(horizontal = 20.dp)
-            .windowInsetsPadding(WindowInsets.navigationBars),
+        modifier = modifier
+            .fillMaxWidth()
+            .background(Theme.color.surfaces.surface)
+            .windowInsetsPadding(WindowInsets.navigationBars)
+            .padding(horizontal = 20.dp, vertical = 16.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -89,8 +91,9 @@ private fun NavigationItem(
 ) {
     val icon = if (isSelected) navItem.filledIcon else navItem.outlinedIcon
     val textColor by animateColorAsState(
-        targetValue = if (isSelected) Theme.color.brand.primary else Theme.color.surfaces.onSurfaceVariant,
-        label = "icon and text color animation"
+        targetValue =
+            if (isSelected) Theme.color.brand.primary
+            else Theme.color.surfaces.onSurfaceVariant,
     )
     Column(
         modifier = modifier.clickable(onClick = onClick, enabled = isClickEnabled),
@@ -100,8 +103,7 @@ private fun NavigationItem(
             targetState = icon,
             transitionSpec = {
                 (fadeIn(tween(450))).togetherWith(fadeOut(tween(450)))
-            },
-            label = "Icon Animation"
+            }
         ) {
             Image(
                 painter = icon,

--- a/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/ui/screen/mealDetails/MealDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/ui/screen/mealDetails/MealDetailsScreen.kt
@@ -43,7 +43,7 @@ fun MealDetailsScreen(
     }
     MealDetailsScreenContent(
         listener = viewModel,
-        state = state ,
+        state = state,
         mealId = mealId
     )
 }

--- a/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/ui/screen/mealDetails/content/MealDetailsSuccessScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/ui/screen/mealDetails/content/MealDetailsSuccessScreen.kt
@@ -85,17 +85,10 @@ fun MealDetailsSuccessScreen(
                 )
             }
         }
-    }
-    if (state.showSaveMealSuccessSnackBar) {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(16.dp),
-            contentAlignment = Alignment.BottomCenter
-        ) {
-            SaveMealSuccessSnackBar(
-                isVisible = state.showSaveMealSuccessSnackBar
-            )
-        }
+        SaveMealSuccessSnackBar(
+            modifier = Modifier.padding(bottom = 24.dp)
+                .align(Alignment.BottomCenter),
+            isVisible = state.showSaveMealSuccessSnackBar
+        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/ui/screen/mealDetails/content/components/SaveMealSuccessSnackBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/ui/screen/mealDetails/content/components/SaveMealSuccessSnackBar.kt
@@ -1,6 +1,8 @@
 package com.cairosquad.evolvefit.ui.screen.mealDetails.content.components
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.cairosquad.evolvefit.design_system.component.SnackBar
 import com.cairosquad.evolvefit.design_system.theme.Theme
 import evolvefit.composeapp.generated.resources.Res
@@ -10,9 +12,10 @@ import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
-fun SaveMealSuccessSnackBar(isVisible : Boolean){
+fun SaveMealSuccessSnackBar(isVisible: Boolean, modifier: Modifier = Modifier) {
     SnackBar(
-        text =  stringResource(Res.string.meal_added_to_your_favourites) ,
+        modifier = modifier,
+        text = stringResource(Res.string.meal_added_to_your_favourites),
         isVisible = isVisible,
         icon = painterResource(Res.drawable.ic_save_tick),
         iconTint = Theme.color.brand.primary

--- a/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/ui/screen/mealsHistory/MealsHistoryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/ui/screen/mealsHistory/MealsHistoryScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import com.cairosquad.evolvefit.design_system.theme.Theme
+import com.cairosquad.evolvefit.ui.screen.mealsHistory.content.components.MealsHistoryEmptyScreen
 import com.cairosquad.evolvefit.ui.screen.mealsHistory.content.components.MealsHistoryErrorScreen
 import com.cairosquad.evolvefit.ui.screen.mealsHistory.content.components.MealsHistoryLoadingScreen
 import com.cairosquad.evolvefit.ui.screen.mealsHistory.content.components.MealsHistorySuccessScreen
@@ -66,6 +67,10 @@ private fun MealsHistoryContent(
 
                 MealHistoryScreenState.ScreenStatus.SUCCESS -> {
                     MealsHistorySuccessScreen(viewModel, state)
+                }
+
+                MealHistoryScreenState.ScreenStatus.EMPTY ->{
+                    MealsHistoryEmptyScreen(viewModel)
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/ui/screen/mealsHistory/content/components/GroupedMealHistoryItem.kt
+++ b/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/ui/screen/mealsHistory/content/components/GroupedMealHistoryItem.kt
@@ -18,13 +18,13 @@ fun GroupedMealHistoryItem(
     Column(modifier = modifier.fillMaxWidth()) {
         Text(
             text = groupedMeal.dayHeader,
-            style = Theme.textStyle.title.largeBold14,
+            style = Theme.textStyle.label.mediumMedium16,
             color = Theme.color.surfaces.onSurface,
             modifier = Modifier
-                .padding(bottom = 8.dp).padding( horizontal = 16.dp)
+                .padding(bottom = 8.dp).padding(horizontal = 16.dp)
         )
 
-        Column{
+        Column {
             groupedMeal.meals.forEach { meal ->
                 MealHistoryItem(
                     meal = meal

--- a/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/ui/screen/mealsHistory/content/components/MealHistoryItem.kt
+++ b/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/ui/screen/mealsHistory/content/components/MealHistoryItem.kt
@@ -1,11 +1,14 @@
 package com.cairosquad.evolvefit.ui.screen.mealsHistory.content.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -33,15 +36,24 @@ fun MealHistoryItem(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
-        Icon(
+        Box(
             modifier = Modifier
+                .size(48.dp)
                 .clip(CircleShape)
-                .background(Theme.color.surfaces.outlineVariant)
-                .padding(10.dp),
-            painter = painterResource(meal.type.icon),
-            contentDescription = null,
-            tint = Theme.color.brand.primary,
-        )
+                .background(Theme.color.surfaces.surfaceContainer)
+                .border(
+                    width = 1.dp,
+                    color = Theme.color.surfaces.outlineVariant,
+                    shape = CircleShape
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                painter = painterResource(meal.type.icon),
+                contentDescription = null,
+                tint = Theme.color.brand.primary,
+            )
+        }
         Column(
             modifier = Modifier
                 .weight(1f)

--- a/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/ui/screen/mealsHistory/content/components/MealsHistoryEmptyScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/ui/screen/mealsHistory/content/components/MealsHistoryEmptyScreen.kt
@@ -1,0 +1,63 @@
+package com.cairosquad.evolvefit.ui.screen.mealsHistory.content.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.cairosquad.evolvefit.design_system.component.StateMessage
+import com.cairosquad.evolvefit.design_system.component.appbar.ActionIconButton
+import com.cairosquad.evolvefit.design_system.component.appbar.CustomAppBar
+import com.cairosquad.evolvefit.design_system.theme.Theme
+import com.cairosquad.evolvefit.viewmodel.meal_history.MealHistoryViewModel
+import evolvefit.composeapp.generated.resources.Res
+import evolvefit.composeapp.generated.resources.back
+import evolvefit.composeapp.generated.resources.ic_back
+import evolvefit.composeapp.generated.resources.ic_no_meals_light
+import evolvefit.composeapp.generated.resources.im_no_meals_recorded
+import evolvefit.composeapp.generated.resources.meal_history
+import evolvefit.composeapp.generated.resources.no_meals_description
+import evolvefit.composeapp.generated.resources.no_meals_title
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun MealsHistoryEmptyScreen(
+    viewModel: MealHistoryViewModel
+) {
+    Column {
+        CustomAppBar(
+            title = stringResource(Res.string.meal_history),
+            modifier = Modifier
+                .windowInsetsPadding(WindowInsets.statusBars)
+                .padding(horizontal = 16.dp),
+            header = {
+                ActionIconButton(
+                    icon = painterResource(Res.drawable.ic_back),
+                    contentDescription = stringResource(Res.string.back),
+                    tint = Theme.color.surfaces.onSurface,
+                    onClick = { viewModel.onNavigateBackClicked() }
+                )
+            }
+
+        )
+        Box(contentAlignment = Alignment.Center) {
+            val noMealsRecorded = if (Theme.isDark) {
+                Res.drawable.im_no_meals_recorded
+            } else {
+                Res.drawable.ic_no_meals_light
+            }
+            StateMessage(
+                modifier = Modifier.padding(vertical = 16.dp),
+                image = painterResource(noMealsRecorded),
+                title = stringResource(Res.string.no_meals_title),
+                description = stringResource(Res.string.no_meals_description)
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/ui/screen/nutrition/component/MealAddedSnackBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/ui/screen/nutrition/component/MealAddedSnackBar.kt
@@ -15,6 +15,7 @@ fun MealAddedSnackBar(
     SnackBar(
         modifier = modifier,
         text = stringResource(Res.string.meal_added_snackbar),
-        isVisible = isVisible
+        isVisible = isVisible,
+        addNavBarPadding = false
     )
 }

--- a/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/ui/screen/nutrition/component/MealCantAddSnackBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/ui/screen/nutrition/component/MealCantAddSnackBar.kt
@@ -19,6 +19,7 @@ import org.jetbrains.compose.resources.stringResource
         modifier = modifier,
         icon = painterResource(Res.drawable.ic_info),
         text = state.errorMessage?.let { stringResource(it) } ?: "",
-        isVisible = isVisible
+        isVisible = isVisible,
+        addNavBarPadding = false,
     )
 }

--- a/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/ui/screen/nutrition/content/NutritionContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/ui/screen/nutrition/content/NutritionContent.kt
@@ -6,9 +6,11 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.cairosquad.evolvefit.design_system.theme.Theme
 import com.cairosquad.evolvefit.ui.component.RefreshBox
 import com.cairosquad.evolvefit.ui.screen.nutrition.component.AddWaterIntakeBottomSheet
@@ -68,11 +70,15 @@ fun NutritionContent(
                 state = state
             )
             MealAddedSnackBar(
-                modifier = Modifier.align(Alignment.BottomCenter),
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 12.dp),
                 isVisible = state.isSnackBarVisible,
             )
             MealCantAddSnackBar(
-                modifier = Modifier.align(Alignment.BottomCenter),
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 12.dp),
                 isVisible = state.isSnackBarVisible,
                 state = state
             )

--- a/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/ui/screen/nutrition/content/NutritionSuccessScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/ui/screen/nutrition/content/NutritionSuccessScreen.kt
@@ -53,7 +53,9 @@ private fun LazyListScope.mealHistorySection(
 ) {
     item {
         SeeAll(
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+            modifier = Modifier
+                .padding(horizontal = 16.dp)
+                .padding(top = 32.dp, bottom = 12.dp),
             onViewAllClick = listener::onViewAllMealHistoryClicked,
             sectionTitle = stringResource(Res.string.meal_history)
         )
@@ -70,7 +72,7 @@ private fun LazyListScope.mealHistorySection(
 }
 
 @Composable
-private fun MealHistoryItem(
+fun MealHistoryItem(
     meal: NutritionScreenState.ConsumedMealUiState,
     modifier: Modifier = Modifier
 ) {
@@ -117,6 +119,7 @@ private fun MealHistoryItem(
                 color = Theme.color.brand.primary
             )
             Text(
+                modifier = Modifier.padding(top = 4.dp),
                 text = stringResource(meal.type.displayName),
                 style = Theme.textStyle.body.smallRegular10,
                 color = Theme.color.surfaces.onSurfaceVariant

--- a/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/viewmodel/meal_history/MealHistoryScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/viewmodel/meal_history/MealHistoryScreenState.kt
@@ -21,7 +21,8 @@ data class MealHistoryScreenState(
     enum class ScreenStatus {
         LOADING,
         ERROR,
-        SUCCESS
+        SUCCESS,
+        EMPTY
     }
 
     data class DayGroupedMealsUiState(

--- a/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/viewmodel/meal_history/MealHistoryViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/viewmodel/meal_history/MealHistoryViewModel.kt
@@ -49,10 +49,15 @@ class MealHistoryViewModel(
 
     private fun onLoadMealsHistorySuccess(mealsHistories: List<ConsumedMeal>) {
         val groupedMeals = groupMealsByDay(mealsHistories.map { it.toMealHistoryUiState() })
+        val status = if (groupedMeals.isEmpty()) {
+            MealHistoryScreenState.ScreenStatus.EMPTY
+        } else {
+            MealHistoryScreenState.ScreenStatus.SUCCESS
+        }
         updateState { current ->
             current.copy(
                 mealsHistories = groupedMeals,
-                screenStatus = MealHistoryScreenState.ScreenStatus.SUCCESS,
+                screenStatus = status,
                 errorMessage = null
             )
         }

--- a/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/viewmodel/nutrition/NutritionViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/viewmodel/nutrition/NutritionViewModel.kt
@@ -367,13 +367,15 @@ class NutritionViewModel(
                 isAddMealSheetVisible = false,
                 mealNameInputError = null,
                 mealCaloriesInputError = null,
-                isInitialLoad = true
+                isInitialLoad = true,
+                mealNameInput = "",
+                consumedCaloriesInput = ""
             )
         }
     }
 
     override fun onDismissWaterClicked() {
-        updateState { it.copy(isAddWaterSheetVisible = false, waterInputError = null) }
+        updateState { it.copy(isAddWaterSheetVisible = false, waterInputError = null, consumedWaterInput = "") }
     }
 
     override fun onRefresh() {


### PR DESCRIPTION
fix issues nutritoion : 
- padding betwenn section and title 
- add empty screen to meals history
- add stroke to meal history icon 
- increase font size to grouped meals (title today )
- padding between name and date 
- update water amount state after close bottom sheet
- snack bar padding

meal history empty screen : 


<img width="408" height="890" alt="image" src="https://github.com/user-attachments/assets/c4c00684-f2cc-4ee8-b360-ddc0291335b3" />



padding sections & meal description  and icon stroke (border ) : 


<img width="402" height="655" alt="image" src="https://github.com/user-attachments/assets/553ac2d6-d8c3-4d0c-8640-f6decaa59219" />
