### PR TITLE
fix:fix padding of error message

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/design_system/component/InputField.kt
+++ b/composeApp/src/commonMain/kotlin/com/cairosquad/evolvefit/design_system/component/InputField.kt
@@ -230,12 +230,11 @@ fun InputField(
         )
         if (error.isNotBlank() && isErrorMessageShown) {
             Row(
-                modifier = Modifier.padding(top = 4.dp),
+                modifier = Modifier.padding(top = 7.dp),
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(4.dp),
             ) {
                 Icon(
-                    modifier = Modifier.size(16.dp),
+                    modifier = Modifier.size(16.dp).padding(end=4.dp),
                     painter = painterResource(Res.drawable.ic_error),
                     contentDescription = "error",
                     tint = Theme.color.system.error


### PR DESCRIPTION
before 
<img width="489" height="295" alt="image" src="https://github.com/user-attachments/assets/fef5aefb-1166-4d01-9749-c3bd0be27593" />

after
<img width="753" height="621" alt="image" src="https://github.com/user-attachments/assets/e6a38741-d364-498c-bc18-8b2094e01a3c" />
